### PR TITLE
fix(auth): authenticate from URL token to survive Safari cookie blocking

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -6,7 +6,12 @@ import { getHemocioneIdUrl } from "~/utils/getHemocioneIdUrl";
 export default defineNuxtRouteMiddleware(async (to, from) => {
   if (import.meta.server) return;
 
-  const isLoggedIn = await evaluateCurrentLogin(from.query);
+  // O token chega na URL de destino (to.query) quando o usuário entra na
+  // integração vindo do digital-event ou retorna do login. Lemos to.query
+  // primeiro e mantemos from.query como rede de segurança. Depender do cookie
+  // .hemocione.com.br quebra no Safari (ITP segura o cookie cross-subdomínio
+  // no primeiro hit), por isso a URL é a fonte primária de auth aqui.
+  const isLoggedIn = await evaluateCurrentLogin({ ...from.query, ...to.query });
   if (!isLoggedIn) {
     redirectToID(to.fullPath);
     return;
@@ -68,8 +73,9 @@ export async function evaluateCurrentLogin(query?: LocationQuery) {
 }
 
 export function getCurrentToken(query?: LocationQuery): string | null {
-  if (query?.token) {
-    return String(query.token);
+  const queryToken = normalizeQueryToken(query?.token);
+  if (queryToken) {
+    return queryToken;
   }
 
   const { token } = useUserStore();
@@ -80,6 +86,21 @@ export function getCurrentToken(query?: LocationQuery): string | null {
   const config = useRuntimeConfig();
   const cookieToken = useCookie(config.public.authCookieKey).value as string;
   return cookieToken;
+}
+
+// A URL pode chegar com mais de um `token`: o hemocione-id faz append do token
+// recém-emitido numa URL que já carregava o token do goToCanDonate, e o
+// vue-router transforma isso num array. Pega o último valor não-vazio, que é o
+// mais recente.
+function normalizeQueryToken(
+  token: LocationQuery[string] | undefined,
+): string | null {
+  if (token == null) return null;
+  if (Array.isArray(token)) {
+    const last = token.filter(Boolean).pop();
+    return last ? String(last) : null;
+  }
+  return String(token);
 }
 
 export function redirectToID(fullPath: string) {


### PR DESCRIPTION
## Problema

No Safari, quem inicia a inscrição num evento e faz login cai no fluxo **on-demand** do posso-doar (sem o botão "Continuar mesmo assim") em vez do **fluxo de evento** — só funciona clicando o link uma 2ª vez, já logado.

## Causa

`middleware/auth.ts` autenticava lendo `from.query` (vazio na entrada externa da integração) + cookie `.hemocione.com.br`. O token JWT na verdade chega em **`to.query`** — o `goToCanDonate` (digital-event) e o retorno do login passam `?token=` de propósito, justamente pra não depender do cookie. Ignorando o token da URL e dependendo do cookie cross-subdomínio, o **Safari/ITP segura esse cookie no primeiro hit** num subdomínio "fresco" (`possodoar`) e a auth falha → a página `/integration` não acha `eventSlug`/`eventDate` autenticado e manda pro on-demand.

## Fix

- Autentica por `to.query` primeiro (`from.query` mantido como rede de segurança).
- `normalizeQueryToken`: trata `token` duplicado — o hemocione-id faz `append` do token numa URL que já carregava um (do `goToCanDonate`), e o vue-router transforma em array → `String(array)` virava token inválido.

Pareado com o digital-event (mesma branch `fix/safari-integration-auth-url-token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication middleware now evaluates query parameters from both origin and destination routes for improved login state detection
  * Enhanced token handling to support multiple formats, improving compatibility with different authentication methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->