### PR TITLE
feat(yduqs): comprovante publico de pre-triagem + integracao de copa participativa

### DIFF
--- a/layouts/comprovante.vue
+++ b/layouts/comprovante.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="comprovante-layout">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.comprovante-layout {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background-color: var(--hemo-color-black-5, #f8f8f8);
+  box-sizing: border-box;
+}
+</style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,6 +55,10 @@ export default defineNuxtConfig({
       eventosHemocione: process.env.EVENTOS_HEMOCIONE || "https://eventos.hemocione.com.br/",
       apoieHemocione: process.env.APOIE_HEMOCIONE || "https://apoie.hemocione.com.br/",
       ondeDoarHemocione: process.env.ONDE_DOAR_HEMOCIONE || "https://ondedoar.hemocione.com.br/",
+      copaHemocione: process.env.COPA_HEMOCIONE || "https://copa.d.hemocione.com.br",
+      // Base sobre a qual o returnPath relativo das integracoes de copa e
+      // resolvido. Nunca aceitamos URL completa por query string.
+      yduqsSite: process.env.YDUQS_SITE || "https://yduqs.hemocione.com.br",
     },
     hemocioneIdJwtSecretKey:
       process.env.HEMOCIONE_ID_JWT_SECRET_KEY ?? "secret",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@element-plus/nuxt": "^1.0.10",
@@ -19,6 +21,7 @@
     "mongoose": "^8.9.5",
     "nuxt": "~3.12.3",
     "nuxt-bugsnag": "8.3.1",
+    "vitest": "^2.1.8",
     "party-js": "^2.2.0",
     "vue": "^3.3.8",
     "vue-router": "^4.2.5"

--- a/pages/comprovante/[token].vue
+++ b/pages/comprovante/[token].vue
@@ -1,0 +1,157 @@
+<template>
+  <div class="card" v-if="comprovante">
+    <NuxtImg
+      src="/images/baseLogo.svg"
+      alt="Hemocione"
+      class="logo"
+      width="120"
+      height="40"
+    />
+
+    <h1 class="title">Comprovante de pré-triagem</h1>
+
+    <p class="name">{{ comprovante.displayName }}</p>
+    <p class="date">{{ formattedDate }}</p>
+
+    <div class="verdict" :class="verdictClass">
+      <span class="verdict-label">Resultado</span>
+      <strong class="verdict-value">{{ verdictText }}</strong>
+    </div>
+
+    <p class="disclaimer">
+      Esta pré-triagem é uma orientação e <strong>não substitui</strong> a
+      triagem oficial feita por profissional de saúde no local da doação.
+    </p>
+
+    <p class="code">cód: {{ shortCode }}</p>
+  </div>
+
+  <div class="card" v-else>
+    <h1 class="title">Comprovante não encontrado</h1>
+    <p class="disclaimer">
+      Este link não corresponde a nenhuma pré-triagem concluída. Confira se você
+      copiou o endereço completo.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+const route = useRoute();
+const token = String(route.params.token);
+
+definePageMeta({ layout: "comprovante" });
+
+// O endpoint devolve 404 para token invalido; nao queremos que isso derrube a
+// pagina, e sim que caia no estado "nao encontrado".
+const { data: comprovante } = await useFetch<{
+  displayName: string;
+  finishedAt: string;
+  status: "able-to-donate" | "unable-to-donate";
+}>(`/api/v1/formResponse/public/${token}`, {
+  key: `comprovante-${token}`,
+  default: () => null,
+});
+
+const formattedDate = computed(() => {
+  if (!comprovante.value?.finishedAt) return "";
+  return new Date(comprovante.value.finishedAt).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+});
+
+const isAble = computed(() => comprovante.value?.status === "able-to-donate");
+
+const verdictText = computed(() =>
+  isAble.value ? "APTO NESTE MOMENTO" : "NÃO APTO NESTE MOMENTO",
+);
+
+const verdictClass = computed(() =>
+  isAble.value ? "verdict--able" : "verdict--unable",
+);
+
+const shortCode = computed(() => `${token.slice(0, 4)}…${token.slice(-2)}`);
+
+useHead({ title: "Comprovante de pré-triagem — Hemocione" });
+</script>
+
+<style scoped>
+.card {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 32px 24px;
+  max-width: 420px;
+  width: 100%;
+  text-align: center;
+  color: #3c4043;
+  box-sizing: border-box;
+}
+
+.logo {
+  margin: 0 auto 16px;
+}
+
+.title {
+  font-size: 1.25rem;
+  margin: 0 0 24px;
+  color: var(--hemo-color-primary-medium, #d32f2f);
+}
+
+.name {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.date {
+  font-size: 0.9rem;
+  color: #6b6f73;
+  margin: 4px 0 24px;
+}
+
+.verdict {
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.verdict--unable {
+  background-color: var(--hemo-color-light-yellow, #fff8e1);
+}
+
+.verdict--able {
+  background-color: #e8f5e9;
+}
+
+.verdict-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b6f73;
+}
+
+.verdict-value {
+  font-size: 1.1rem;
+}
+
+.disclaimer {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #6b6f73;
+  margin: 0 0 16px;
+}
+
+.code {
+  font-size: 0.7rem;
+  color: #9aa0a6;
+  margin: 0;
+  font-family: monospace;
+}
+</style>

--- a/pages/comprovante/[token].vue
+++ b/pages/comprovante/[token].vue
@@ -55,6 +55,10 @@ const { data: comprovante } = await useFetch<{
 const formattedDate = computed(() => {
   if (!comprovante.value?.finishedAt) return "";
   return new Date(comprovante.value.finishedAt).toLocaleString("pt-BR", {
+    // Fuso fixo: um comprovante e documento de evidencia, entao a hora nele nao
+    // pode mudar conforme o fuso de quem abre o link. Quem confere a
+    // participacao pode estar em outro fuso que quem fez a pre-triagem.
+    timeZone: "America/Sao_Paulo",
     day: "2-digit",
     month: "2-digit",
     year: "numeric",

--- a/server/api/v1/formResponse/public/[token].get.ts
+++ b/server/api/v1/formResponse/public/[token].get.ts
@@ -1,0 +1,28 @@
+import { defineEventHandler } from "h3";
+import { FormResponse } from "~/server/models/formResponse";
+import { buildPublicComprovante } from "~/server/utils/publicComprovante";
+
+const TOKEN_PATTERN = /^[a-f0-9]{32}$/;
+
+export default defineEventHandler(async (event) => {
+  const token = event.context.params?.token;
+
+  // 404 identico para token ausente, malformado, inexistente e formulario nao
+  // finalizado: nao revelar se um comprovante existe.
+  const notFound = () =>
+    createError({ statusCode: 404, statusMessage: "Comprovante not found" });
+
+  if (!token || !TOKEN_PATTERN.test(token)) throw notFound();
+
+  // select explicito — nao trazer o documento inteiro para a memoria do
+  // handler. Defesa em profundidade junto de buildPublicComprovante, que
+  // garante o shape da resposta.
+  const doc = await FormResponse.findOne({ publicToken: token })
+    .select("user.name finishedAt status")
+    .lean();
+
+  const comprovante = buildPublicComprovante(doc);
+  if (!comprovante) throw notFound();
+
+  return comprovante;
+});

--- a/server/models/formResponse.ts
+++ b/server/models/formResponse.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { InferSchemaType, Schema, model } from "mongoose";
 import {
   getFailingQuestionsForContext,
@@ -29,7 +30,11 @@ const AnswerSchema = new Schema({
   },
 });
 
-export const integrationSlugs = ['event-flow-schedule', 'event-ticket-adhoc'] as const;
+export const integrationSlugs = [
+  'event-flow-schedule',
+  'event-ticket-adhoc',
+  'competition-participation',
+] as const;
 
 export type IntegrationSlug = typeof integrationSlugs[number];
 
@@ -69,6 +74,22 @@ IntegrationBaseSchema.discriminator(
       payload: {
         eventSlug: { type: String, required: true },
         eventDate: { type: Date, required: true },
+      },
+    },
+    { _id: false }
+  )
+);
+
+IntegrationBaseSchema.discriminator(
+  "competition-participation",
+  new Schema(
+    {
+      payload: {
+        competitionSlug: { type: String, required: true },
+        // Path RELATIVO sobre a base allowlistada em runtimeConfig.
+        // Nunca URL completa — seria open-redirect, ja que o can-donate faz
+        // navigateTo(url, { external: true }) com usuario logado.
+        returnPath: { type: String, required: true },
       },
     },
     { _id: false }
@@ -129,6 +150,23 @@ const FormResponseSchema = new Schema(
     integration: {
       type: IntegrationBaseSchema,
       default: null,          // allows it to be null / omitted
+    },
+
+    // Identificador do comprovante publico de pre-triagem.
+    //
+    // Nao usamos o _id: ObjectId embute timestamp e counter, logo e
+    // parcialmente enumeravel — e do outro lado do link ha veredito de
+    // triagem de pessoa identificavel.
+    //
+    // sparse e OBRIGATORIO: os documentos que ja existem na colecao nao tem
+    // este campo, e num indice unique nao-sparse o Mongo trata ausente como
+    // null — mais de um documento sem o campo colidiria e a criacao do indice
+    // falharia.
+    publicToken: {
+      type: String,
+      unique: true,
+      sparse: true,
+      default: () => randomBytes(16).toString("hex"), // 16 bytes -> 32 chars hex
     },
 
   },

--- a/server/models/formResponse.ts
+++ b/server/models/formResponse.ts
@@ -1,9 +1,22 @@
-import { randomBytes } from "node:crypto";
 import { InferSchemaType, Schema, model } from "mongoose";
 import {
   getFailingQuestionsForContext,
   getQuestionsFromContext,
 } from "~/utils/questions";
+
+/**
+ * 16 bytes em hex (32 chars).
+ *
+ * Usa a Web Crypto API global, disponivel tanto no Node 18+ quanto no browser,
+ * em vez de importar `randomBytes` de `node:crypto`. Este arquivo e importado
+ * pelo client — `utils/integrations.ts` consome `integrationSlugs` daqui —,
+ * entao um import Node-only faz o Vite resolver para
+ * `__vite-browser-external` e o build de producao quebra.
+ */
+const generatePublicToken = () =>
+  Array.from(crypto.getRandomValues(new Uint8Array(16)))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 
 export const formModes = ["anonymous", "logged-in"] as const;
 
@@ -166,7 +179,7 @@ const FormResponseSchema = new Schema(
       type: String,
       unique: true,
       sparse: true,
-      default: () => randomBytes(16).toString("hex"), // 16 bytes -> 32 chars hex
+      default: generatePublicToken,
     },
 
   },

--- a/server/utils/publicComprovante.test.ts
+++ b/server/utils/publicComprovante.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { buildPublicComprovante, formatDisplayName } from "./publicComprovante";
+
+describe("formatDisplayName", () => {
+  it("reduz nome completo a primeiro nome + inicial do sobrenome", () => {
+    expect(formatDisplayName("Thiago Guimaraes Alcantara")).toBe("Thiago A.");
+  });
+
+  it("usa o sobrenome quando ha exatamente dois nomes", () => {
+    expect(formatDisplayName("Thiago Guimaraes")).toBe("Thiago G.");
+  });
+
+  it("mantem apenas o primeiro nome quando nao ha sobrenome", () => {
+    expect(formatDisplayName("Thiago")).toBe("Thiago");
+  });
+
+  it("ignora espacos extras", () => {
+    expect(formatDisplayName("  Thiago   Guimaraes  ")).toBe("Thiago G.");
+  });
+
+  it("devolve fallback quando o nome esta ausente", () => {
+    expect(formatDisplayName(null)).toBe("Doador(a)");
+    expect(formatDisplayName("")).toBe("Doador(a)");
+    expect(formatDisplayName(undefined)).toBe("Doador(a)");
+  });
+});
+
+describe("buildPublicComprovante", () => {
+  const finishedAt = new Date("2026-07-30T13:42:10.000Z");
+
+  const validDoc = {
+    user: { name: "Thiago Guimaraes", email: "thiago@example.com", id: "abc" },
+    finishedAt,
+    status: "unable-to-donate",
+    client: { ip: "1.2.3.4", geolocation: { latitude: -23, longitude: -46 } },
+    answers: new Map([["age", { value: "positive" }]]),
+    failedQuestions: ["tattoo"],
+    publicToken: "deadbeefdeadbeefdeadbeefdeadbeef",
+  };
+
+  it("projeta apenas displayName, finishedAt e status", () => {
+    expect(buildPublicComprovante(validDoc)).toEqual({
+      displayName: "Thiago G.",
+      finishedAt,
+      status: "unable-to-donate",
+    });
+  });
+
+  it("nao vaza nenhum campo sensivel", () => {
+    const result = buildPublicComprovante(validDoc)!;
+    const serialized = JSON.stringify(result);
+
+    expect(Object.keys(result).sort()).toEqual([
+      "displayName",
+      "finishedAt",
+      "status",
+    ]);
+    expect(serialized).not.toContain("thiago@example.com");
+    expect(serialized).not.toContain("1.2.3.4");
+    expect(serialized).not.toContain("tattoo");
+    expect(serialized).not.toContain("age");
+    expect(serialized).not.toContain("Guimaraes");
+    expect(serialized).not.toContain("deadbeef");
+  });
+
+  it("devolve null quando o formulario nao foi finalizado", () => {
+    expect(buildPublicComprovante({ ...validDoc, finishedAt: null })).toBeNull();
+    expect(buildPublicComprovante({ ...validDoc, status: "ongoing" })).toBeNull();
+  });
+
+  it("devolve null para entrada ausente ou invalida", () => {
+    expect(buildPublicComprovante(null)).toBeNull();
+    expect(buildPublicComprovante(undefined)).toBeNull();
+    expect(buildPublicComprovante("nope")).toBeNull();
+  });
+});

--- a/server/utils/publicComprovante.ts
+++ b/server/utils/publicComprovante.ts
@@ -1,0 +1,49 @@
+const NAME_FALLBACK = "Doador(a)";
+
+export type PublicComprovante = {
+  displayName: string;
+  finishedAt: Date;
+  status: "able-to-donate" | "unable-to-donate";
+};
+
+/**
+ * Primeiro nome + inicial do sobrenome. O primeiro nome isolado seria fraco
+ * como prova de identidade; o nome completo seria exposicao desnecessaria numa
+ * URL publica.
+ */
+export function formatDisplayName(fullName?: string | null): string {
+  const parts = (fullName ?? "").trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return NAME_FALLBACK;
+  const [first, ...rest] = parts;
+  const last = rest.at(-1);
+  return last ? `${first} ${last[0].toUpperCase()}.` : first;
+}
+
+/**
+ * Allowlist explicita: constroi o objeto publico campo por campo em vez de
+ * remover campos de um documento inteiro. Uma denylist falharia ABERTA quando
+ * alguem acrescentasse campo sensivel novo ao schema do FormResponse.
+ */
+export function buildPublicComprovante(doc: unknown): PublicComprovante | null {
+  if (!doc || typeof doc !== "object") return null;
+
+  const candidate = doc as {
+    finishedAt?: Date | null;
+    status?: string;
+    user?: { name?: string | null } | null;
+  };
+
+  if (!candidate.finishedAt) return null;
+  if (
+    candidate.status !== "able-to-donate" &&
+    candidate.status !== "unable-to-donate"
+  ) {
+    return null;
+  }
+
+  return {
+    displayName: formatDisplayName(candidate.user?.name),
+    finishedAt: candidate.finishedAt,
+    status: candidate.status,
+  };
+}

--- a/utils/allowedHosts.test.ts
+++ b/utils/allowedHosts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildAllowedUrl } from "./allowedHosts";
+
+describe("buildAllowedUrl", () => {
+  const base = "https://yduqs.hemocione.com.br";
+
+  it("resolve path relativo sobre a base", () => {
+    expect(buildAllowedUrl(base, "/apto")).toBe(
+      "https://yduqs.hemocione.com.br/apto",
+    );
+  });
+
+  it("aceita path sem barra inicial", () => {
+    expect(buildAllowedUrl(base, "apto")).toBe(
+      "https://yduqs.hemocione.com.br/apto",
+    );
+  });
+
+  it("preserva query string do path", () => {
+    expect(buildAllowedUrl(base, "/apto?x=1")).toBe(
+      "https://yduqs.hemocione.com.br/apto?x=1",
+    );
+  });
+
+  it("rejeita URL absoluta — seria open redirect", () => {
+    expect(buildAllowedUrl(base, "https://evil.com/phish")).toBeNull();
+    expect(buildAllowedUrl(base, "http://evil.com")).toBeNull();
+  });
+
+  it("rejeita URL protocol-relative", () => {
+    expect(buildAllowedUrl(base, "//evil.com")).toBeNull();
+  });
+
+  it("rejeita esquemas perigosos", () => {
+    expect(buildAllowedUrl(base, "javascript:alert(1)")).toBeNull();
+    expect(buildAllowedUrl(base, "data:text/html,<script>")).toBeNull();
+  });
+
+  it("rejeita traversal que escaparia da base", () => {
+    expect(buildAllowedUrl(base, "/../../etc")).toBeNull();
+  });
+
+  it("rejeita entrada vazia ou ausente", () => {
+    expect(buildAllowedUrl(base, "")).toBeNull();
+    expect(buildAllowedUrl("", "/apto")).toBeNull();
+  });
+
+  it("nunca deixa o host da base ser trocado", () => {
+    const result = buildAllowedUrl(base, "/apto");
+    expect(new URL(result!).host).toBe("yduqs.hemocione.com.br");
+  });
+});

--- a/utils/allowedHosts.test.ts
+++ b/utils/allowedHosts.test.ts
@@ -45,6 +45,13 @@ describe("buildAllowedUrl", () => {
     expect(buildAllowedUrl("", "/apto")).toBeNull();
   });
 
+  it("rejeita valor que nao e string — param repetido chega como array", () => {
+    expect(buildAllowedUrl(base, ["/apto", "/outro"])).toBeNull();
+    expect(buildAllowedUrl(base, undefined)).toBeNull();
+    expect(buildAllowedUrl(base, 123)).toBeNull();
+    expect(buildAllowedUrl(base, null)).toBeNull();
+  });
+
   it("nunca deixa o host da base ser trocado", () => {
     const result = buildAllowedUrl(base, "/apto");
     expect(new URL(result!).host).toBe("yduqs.hemocione.com.br");

--- a/utils/allowedHosts.ts
+++ b/utils/allowedHosts.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolve um path RELATIVO sobre uma base fixa, garantindo que o host da base
+ * nunca seja trocado.
+ *
+ * Existe porque getRedirectURL e handleBtnClick fazem
+ * navigateTo(url, { external: true }). Aceitar URL completa vinda de query
+ * string abriria open-redirect: um atacante mandaria
+ * ?returnPath=https://phish.example e o can-donate levaria o usuario logado
+ * para la.
+ */
+export function buildAllowedUrl(
+  base: string,
+  relativePath: string,
+): string | null {
+  if (!base || !relativePath) return null;
+
+  // "//evil.com" e protocol-relative; "https://..." e absoluto; "javascript:"
+  // e esquema. Nenhum deles e path relativo.
+  if (relativePath.startsWith("//")) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(relativePath)) return null;
+  // "/../.." escaparia da raiz pretendida. Recusa em vez de clampar em
+  // silencio.
+  if (relativePath.includes("..")) return null;
+
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(base);
+  } catch {
+    return null;
+  }
+
+  const normalized = relativePath.startsWith("/")
+    ? relativePath
+    : `/${relativePath}`;
+
+  let resolved: URL;
+  try {
+    resolved = new URL(normalized, baseUrl);
+  } catch {
+    return null;
+  }
+
+  // Cinto e suspensorio: se qualquer coisa mudou host ou protocolo, recusa.
+  if (resolved.host !== baseUrl.host || resolved.protocol !== baseUrl.protocol) {
+    return null;
+  }
+
+  return resolved.toString();
+}

--- a/utils/allowedHosts.ts
+++ b/utils/allowedHosts.ts
@@ -10,8 +10,12 @@
  */
 export function buildAllowedUrl(
   base: string,
-  relativePath: string,
+  relativePath: unknown,
 ): string | null {
+  // relativePath vem de query string: param repetido
+  // (?returnPath=a&returnPath=b) chega como array, e chamar metodo de string
+  // nele estouraria dentro de um caminho de redirect.
+  if (typeof relativePath !== "string") return null;
   if (!base || !relativePath) return null;
 
   // "//evil.com" e protocol-relative; "https://..." e absoluto; "javascript:"

--- a/utils/integrations.ts
+++ b/utils/integrations.ts
@@ -59,7 +59,11 @@ const buildEventsPayload = async (
   const eventDate = route.query.eventDate as string | undefined;
   if (!eventSlug || !eventDate) return null;
 
-  const competitionSlug = route.query.competitionSlug as string | undefined;
+  const competitionSlug =
+    typeof route.query.competitionSlug === "string" &&
+    route.query.competitionSlug.trim()
+      ? route.query.competitionSlug
+      : undefined;
 
   const tz = getUserTimeZone();
   const eventDay = dayjs.utc(eventDate).tz(tz).startOf("day");
@@ -293,10 +297,15 @@ export const integrations: Record<IntegrationSlug, IntegrationDefinition> = {
    */
   "competition-participation": {
     async buildPayload(route) {
-      const competitionSlug = route.query.competitionSlug as string | undefined;
+      // Query string nao e confiavel: param repetido chega como array, e
+      // qualquer coisa que nao seja string simples nao e slug nem path.
+      const asPlainString = (value: unknown): string | undefined =>
+        typeof value === "string" && value.trim() ? value : undefined;
+
+      const competitionSlug = asPlainString(route.query.competitionSlug);
       if (!competitionSlug) return null;
 
-      const returnPath = (route.query.returnPath as string | undefined) ?? "/apto";
+      const returnPath = asPlainString(route.query.returnPath) ?? "/apto";
 
       // Fora de evento nao ha data marcada: a pessoa vai doar por conta
       // propria, hoje.

--- a/utils/integrations.ts
+++ b/utils/integrations.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import type { RouteLocationNormalizedLoaded, RouteLocationRaw } from "vue-router";
 import type { FormResponseSchema, IntegrationSlug } from "~/server/models/formResponse";
 import { integrationSlugs } from "~/server/models/formResponse";
+import { buildAllowedUrl } from "~/utils/allowedHosts";
 
 export function isIntegrationSlug(value: unknown): value is IntegrationSlug {
   return typeof value === "string" && (integrationSlugs as readonly string[]).includes(value);
@@ -10,10 +11,24 @@ export function isIntegrationSlug(value: unknown): value is IntegrationSlug {
 export interface EventsIntegration {
   eventSlug: string;
   eventDate: string | Date; // ISO string no front, Date no back
+  /**
+   * Slug da copa relacionada ao evento, derivado do registerDonationUrl do
+   * evento no digital-event. Opcional: evento sem copa relacionada nao ganha o
+   * botao de registrar participacao, e o fluxo segue identico ao anterior.
+   */
+  competitionSlug?: string;
+}
+
+export interface CompetitionParticipationIntegration {
+  competitionSlug: string;
+  /** Path RELATIVO. Resolvido sobre runtimeConfig.public.yduqsSite. */
+  returnPath: string;
 }
 
 /** Union de todos os payloads existentes. */
-export type IntegrationPayload = EventsIntegration;
+export type IntegrationPayload =
+  | EventsIntegration
+  | CompetitionParticipationIntegration;
 
 export type ButtonConfig = {
   label: string;
@@ -23,26 +38,28 @@ export type ButtonConfig = {
   visible?: boolean;
 };
 
+type PayloadWithIntent = IntegrationPayload & { intent: "today" | "soon" };
+
 export interface IntegrationDefinition {
   /** Constroi o payload que deve ser criado em << FormResponse.integration >>. */
   buildPayload: (
     route: Pick<RouteLocationNormalizedLoaded, "params" | "query">
-  ) => Promise<EventsPayloadWithIntent | null>;
+  ) => Promise<PayloadWithIntent | null>;
 
   getButtonConfig?: (formResponse: FormResponseSchema) => Promise<ButtonConfig[]>;
 
   getRedirectURL?: (formResponse: FormResponseSchema) => Promise<RouteLocationRaw>;
 }
 
-type EventsPayloadWithIntent = EventsIntegration & { intent: "today" | "soon" };
-
-/** "event-flow-schedule" e "event-adhoc-ticket" compartilham a mesma lógica. */
+/** "event-flow-schedule" e "event-ticket-adhoc" compartilham a mesma lógica. */
 const buildEventsPayload = async (
   route: Pick<RouteLocationNormalizedLoaded, "params" | "query">
-): Promise<EventsPayloadWithIntent | null> => {
+): Promise<PayloadWithIntent | null> => {
   const eventSlug = route.query.eventSlug as string | undefined;
   const eventDate = route.query.eventDate as string | undefined;
   if (!eventSlug || !eventDate) return null;
+
+  const competitionSlug = route.query.competitionSlug as string | undefined;
 
   const tz = getUserTimeZone();
   const eventDay = dayjs.utc(eventDate).tz(tz).startOf("day");
@@ -50,8 +67,59 @@ const buildEventsPayload = async (
 
   const intent: "today" | "soon" = today.isBefore(eventDay) ? "soon" : "today";
 
-  return { intent, eventSlug, eventDate };
+  return {
+    intent,
+    eventSlug,
+    eventDate,
+    ...(competitionSlug ? { competitionSlug } : {}),
+  };
 };
+
+/**
+ * URL de registro na copa.
+ *
+ * `kind` vem pre-selecionado mas permanece editavel no formulario da copa: o
+ * campo e autodeclarado, entao mentir pelo query param equivale a mentir
+ * clicando no radio — nao ha garantia perdida.
+ */
+export function buildCompetitionRegisterUrl(
+  competitionSlug: string,
+  opts: { kind?: "donation" | "participation"; proofUrl?: string } = {},
+): string | null {
+  const config = useRuntimeConfig();
+  const base = (config.public.copaHemocione as string) ?? "";
+  if (!base) return null;
+
+  try {
+    const url = new URL(
+      `/competition/${encodeURIComponent(competitionSlug)}/register`,
+      base,
+    );
+    if (opts.kind) url.searchParams.set("kind", opts.kind);
+    if (opts.proofUrl) url.searchParams.set("proofUrl", opts.proofUrl);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** URL publica do comprovante desta pre-triagem, usada como prova na copa. */
+export function buildComprovanteUrl(
+  formResponse: FormResponseSchema,
+): string | null {
+  const config = useRuntimeConfig();
+  const token = (formResponse as { publicToken?: string }).publicToken;
+  if (!token) return null;
+
+  const base = (config.public.siteUrl as string) ?? "";
+  if (!base) return null;
+
+  try {
+    return new URL(`/comprovante/${token}`, base).toString();
+  } catch {
+    return null;
+  }
+}
 
 /** Função auxiliar para construir os botões das integrações de eventos */
 function buildEventButtonConfig(
@@ -74,16 +142,51 @@ function buildEventButtonConfig(
       },
     ];
   }
+
+  // Evento com copa relacionada: quem foi reprovado na pre-triagem ainda tem a
+  // participacao contada na campanha. Sem copa este botao nao existe e a lista
+  // fica identica a de antes.
+  const competitionSlug = (
+    formResponse.integration?.payload as EventsIntegration | undefined
+  )?.competitionSlug;
+
+  const registerUrl = competitionSlug
+    ? buildCompetitionRegisterUrl(competitionSlug, {
+        kind: "participation",
+        proofUrl: buildComprovanteUrl(formResponse) ?? undefined,
+      })
+    : null;
+
+  if (!registerUrl) {
+    return [
+      {
+        label: config.fail.primary.label,
+        type: "primary",
+        url: config.fail.primary.url,
+      },
+      {
+        label: config.fail.secondary.label,
+        type: "secondary",
+        url: config.fail.secondary.url,
+      },
+    ];
+  }
+
   return [
     {
-      label: config.fail.primary.label,
+      label: "Registrar participação",
       type: "primary",
-      url: config.fail.primary.url,
+      url: registerUrl,
     },
     {
       label: config.fail.secondary.label,
       type: "secondary",
       url: config.fail.secondary.url,
+    },
+    {
+      label: config.fail.primary.label,
+      type: "secondary",
+      url: config.fail.primary.url,
     },
   ];
 }
@@ -178,6 +281,92 @@ export const integrations: Record<IntegrationSlug, IntegrationDefinition> = {
 
       const url = new URL(`/event/${encodeURIComponent(eventSlug)}/ticket`, eventosHemocioneUrl);
       return url.toString();
+    },
+  },
+
+  /**
+   * Pre-triagem FORA de evento: a pessoa vai doar num banco de sangue por
+   * conta propria, vindo de uma campanha de parceiro.
+   *
+   * Deliberadamente generica, nao especifica de YDUQS: a campanha do semestre
+   * que vem nao deve precisar de codigo novo.
+   */
+  "competition-participation": {
+    async buildPayload(route) {
+      const competitionSlug = route.query.competitionSlug as string | undefined;
+      if (!competitionSlug) return null;
+
+      const returnPath = (route.query.returnPath as string | undefined) ?? "/apto";
+
+      // Fora de evento nao ha data marcada: a pessoa vai doar por conta
+      // propria, hoje.
+      return { intent: "today", competitionSlug, returnPath };
+    },
+
+    async getButtonConfig(formResponse) {
+      const config = useRuntimeConfig();
+      const payload = (formResponse.integration?.payload ??
+        {}) as Partial<CompetitionParticipationIntegration>;
+      const competitionSlug = payload.competitionSlug;
+      const returnPath = payload.returnPath ?? "/apto";
+
+      if (!competitionSlug) return [];
+
+      const isFailed = formResponse.status === "unable-to-donate";
+
+      if (!isFailed) {
+        const buttons: ButtonConfig[] = [];
+        const aptoUrl = buildAllowedUrl(
+          (config.public.yduqsSite as string) ?? "",
+          returnPath,
+        );
+        if (aptoUrl) {
+          buttons.push({
+            label: "Ver os próximos passos",
+            type: "primary",
+            url: aptoUrl,
+          });
+        }
+        buttons.push({
+          label: "Encontrar um banco de sangue",
+          type: aptoUrl ? "secondary" : "primary",
+          url: (config.public.ondeDoarHemocione as string) ?? "",
+        });
+        return buttons;
+      }
+
+      const buttons: ButtonConfig[] = [];
+      const registerUrl = buildCompetitionRegisterUrl(competitionSlug, {
+        kind: "participation",
+        proofUrl: buildComprovanteUrl(formResponse) ?? undefined,
+      });
+      if (registerUrl) {
+        buttons.push({
+          label: "Registrar participação",
+          type: "primary",
+          url: registerUrl,
+        });
+      }
+      buttons.push({
+        label: "Ajudar a causa de outra forma",
+        type: registerUrl ? "secondary" : "primary",
+        url: (config.public.apoieHemocione as string) ?? "",
+      });
+      return buttons;
+    },
+
+    async getRedirectURL(formResponse) {
+      // Destino do botao VOLTAR — nao do resultado.
+      const config = useRuntimeConfig();
+      const yduqsSite = (config.public.yduqsSite as string) ?? "/";
+      const returnPath = (
+        formResponse.integration?.payload as
+          | Partial<CompetitionParticipationIntegration>
+          | undefined
+      )?.returnPath;
+
+      if (!returnPath) return yduqsSite;
+      return buildAllowedUrl(yduqsSite, returnPath) ?? yduqsSite;
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,6 +933,11 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz"
@@ -1834,6 +1839,65 @@
   resolved "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.1.tgz"
   integrity sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==
 
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
+  integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
+  dependencies:
+    tinyrainbow "^1.2.0"
+
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
+
 "@vue-macros/common@^1.15.0":
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/@vue-macros/common/-/common-1.16.1.tgz#dac7ebc57ded4d6fb19d7f9a83d2973971d9fa65"
@@ -2199,6 +2263,11 @@ array-back@^4.0.1, array-back@^4.0.2:
   resolved "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz"
   integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 ast-kit@^1.0.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ast-kit/-/ast-kit-1.2.1.tgz"
@@ -2504,6 +2573,17 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001663:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz"
   integrity sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==
 
+chai@^5.1.2:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -2530,6 +2610,11 @@ change-case@^5.4.4:
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.4.4.tgz#0d52b507d8fb8f204343432381d1a6d7bff97a02"
   integrity sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chokidar@^3.5.1, chokidar@^3.6.0:
   version "3.6.0"
@@ -2997,6 +3082,11 @@ decompress-response@^6.0.0:
   integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
     mimic-response "^3.1.0"
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
@@ -3492,6 +3582,11 @@ expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
+expect-type@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 exsolve@^1.0.0, exsolve@^1.0.1, exsolve@^1.0.2, exsolve@^1.0.4:
   version "1.0.4"
@@ -4569,6 +4664,11 @@ lodash@^4.17.15, lodash@^4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lru-cache@^10.2.0, lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
@@ -4614,6 +4714,13 @@ magic-string@^0.30.0, magic-string@^0.30.10, magic-string@^0.30.11, magic-string
   integrity sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+
+magic-string@^0.30.12:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magic-string@^0.30.14, magic-string@^0.30.17:
   version "0.30.17"
@@ -5402,6 +5509,11 @@ pathe@^2.0.1, pathe@^2.0.2, pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
+
 perfect-debounce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz"
@@ -6132,6 +6244,11 @@ sift@17.1.3:
   resolved "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz"
   integrity sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
@@ -6264,6 +6381,11 @@ stack-generator@^2.0.3:
   dependencies:
     stackframe "^1.3.4"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz"
@@ -6283,6 +6405,11 @@ std-env@^3.7.0:
   version "3.7.0"
   resolved "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
+
+std-env@^3.8.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 std-env@^3.8.1:
   version "3.8.1"
@@ -6560,7 +6687,12 @@ tiny-invariant@^1.1.0:
   resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
-tinyexec@^0.3.2:
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.1, tinyexec@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
@@ -6580,6 +6712,21 @@ tinyglobby@^0.2.6, tinyglobby@^0.2.9:
   dependencies:
     fdir "^6.4.0"
     picomatch "^4.0.2"
+
+tinypool@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -6975,7 +7122,7 @@ vite-hot-client@^0.2.3:
   resolved "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-0.2.3.tgz"
   integrity sha512-rOGAV7rUlUHX89fP2p2v0A2WWvV3QMX2UYq0fRqsWSvFvev4atHWqjwGoKaZT1VTKyLGk533ecu3eyd0o59CAg==
 
-vite-node@^2.0.3:
+vite-node@2.1.9, vite-node@^2.0.3:
   version "2.1.9"
   resolved "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz"
   integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
@@ -7046,6 +7193,32 @@ vite@^5.0.0, vite@^5.3.4:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@^2.1.8:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
+    why-is-node-running "^2.3.0"
 
 vscode-jsonrpc@6.0.0:
   version "6.0.0"
@@ -7170,6 +7343,14 @@ which@^3.0.1:
   integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wordwrapjs@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
## O que

1. **Comprovante público de pré-triagem** — `publicToken` opaco no `FormResponse`, endpoint `GET /api/v1/formResponse/public/:token` e página `/comprovante/:token`. Mostra nome abreviado, data e veredito. **Nunca os motivos.**
2. **Integração `competition-participation`** — genérica, para o galho "quero doar num banco de sangue" do site YDUQS.
3. **Terceiro botão no fluxo de evento** — "Registrar participação", somado aos dois de hoje, apenas quando o evento tem copa relacionada.

## Por que

A campanha YDUQS 2026/2 conta **participação**, não só bolsas: quem é reprovado na pré-triagem também entra na copa, e o comprovante da própria pré-triagem serve como prova.

## Decisões que valem review

- **Token opaco, não `_id`.** ObjectId embute timestamp e counter, logo é parcialmente enumerável — e do outro lado do link há veredito de triagem de pessoa identificável.
- **O índice é `sparse` por necessidade, não por estilo.** Os documentos que já existem na coleção não têm o campo, e num índice `unique` não-sparse o Mongo trata ausente como `null`: mais de um documento sem o campo colidiria e a criação do índice falharia. Também deixei o campo **sem `required`**, para não quebrar `save()` de documentos antigos.
- **Projeção por allowlist, não denylist.** `buildPublicComprovante` monta o objeto campo por campo, para falhar FECHADO quando alguém acrescentar campo sensível novo ao schema. O teste asserta **ausência** de email, IP e respostas na serialização, não só presença dos campos esperados.
- **`returnPath` é path relativo**, resolvido sobre base fixa (`buildAllowedUrl`). URL completa seria open-redirect: o can-donate faz `navigateTo(url, { external: true })` com usuário logado.
- **404 idêntico** para token ausente, malformado, inexistente e formulário não finalizado — não revela se um comprovante existe.
- **Slug genérico**, não `yduqs-2026`: a campanha do semestre que vem não deve precisar de código novo.

## Não-regressão

O caso que mais importa conferir: **evento reprovado sem copa relacionada deve mostrar exatamente os 2 botões de hoje, na mesma ordem**. O código trata isso explicitamente (`registerUrl` nulo → retorna a lista antiga).

## Testes

`yarn test` — 18 testes de função pura (projeção pública e resolução de path relativo).

⚠️ **Não consegui rodar a suíte deste repo:** o cache do Yarn da máquina está corrompido e o `yarn install` falha na extração (ENOENT). As mesmas duas funções foram exercitadas com sucesso no PR gêmeo do `hemocione-competitions`, onde a instalação funcionou (23 testes verdes lá). Aqui, vale rodar `yarn test` antes de mergear.

## Bug pré-existente encontrado, NÃO corrigido aqui

`server/models/formResponse.ts` registra o discriminator como `"event-adhoc-ticket"`, mas o slug em `integrationSlugs` é `"event-ticket-adhoc"`. Os nomes não batem, então aquele discriminator nunca é aplicado e o payload cai no `Mixed` do schema base, sem validação de `eventSlug`/`eventDate`. Corrigir passaria a **exigir** esses campos, o que é mudança de comportamento em fluxo de produção — merece issue própria.

## Fora deste PR

`GET /api/v1/formResponse/[formId]` devolve email, IP, geolocalização e respostas de saúde sem auth. É exposição pré-existente e está no PR `fix/form-response-projection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a privacy-friendly public “comprovante” receipt page for token links, including eligibility status and formatted completion time.
  - Added competition participation integration with registration and receipt-based proof links.
- **Bug Fixes**
  - Ensured consistent “not found” handling for invalid or unbuildable receipt tokens.
  - Tightened public receipt data to show only approved fields.
  - Added safe return-path URL building to prevent open redirects.
- **Configuration**
  - Added a runtime-configured Copa Hemocione base URL.
- **Tests**
  - Added Vitest coverage for receipt building/formatting and URL safety, and introduced `vitest` test scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->