### PR TITLE
fix(form-response): restringir projecao do GET sem autenticacao

### DIFF
--- a/server/api/v1/formResponse/[formId]/index.get.ts
+++ b/server/api/v1/formResponse/[formId]/index.get.ts
@@ -2,10 +2,36 @@
 import { defineEventHandler } from "h3";
 import { FormResponse } from "~/server/models/formResponse";
 
+// Allowlist explicita dos campos que o front realmente consome.
+//
+// O handler devolvia o documento INTEIRO, sem autenticacao nenhuma: incluia
+// user.email, client.ip, client.geolocation e o mapa completo de respostas de
+// triagem — que sao dado de saude — sob um _id que e ObjectId, logo
+// parcialmente enumeravel.
+//
+// Allowlist e nao denylist de proposito: falha FECHADO quando alguem
+// acrescentar campo sensivel novo ao schema.
+const FRONTEND_FIELDS = [
+  "mode",
+  "user.name",
+  "user.id",
+  "donationIntent",
+  "answers",
+  "startedAt",
+  "finishedAt",
+  "status",
+  "failedQuestions",
+  "integration",
+  // Campo introduzido pelo PR do comprovante publico. Selecionar um path que
+  // ainda nao existe no schema e no-op no Mongo, entao este arquivo funciona
+  // nas duas ordens de merge.
+  "publicToken",
+].join(" ");
+
 export default defineEventHandler(async (event) => {
   const formId = event.context.params?.formId;
 
-  const formResponse = await FormResponse.findById(formId);
+  const formResponse = await FormResponse.findById(formId).select(FRONTEND_FIELDS);
   if (!formResponse) {
     throw createError({
       statusCode: 404,


### PR DESCRIPTION
## O que

`GET /api/v1/formResponse/:formId` passa a devolver apenas os campos que o front consome, via allowlist explícita.

## Por que

O handler devolvia o documento **inteiro**, **sem autenticação nenhuma**:

- `user.email`
- `client.ip`
- `client.geolocation`
- o mapa completo de `answers` e `failedQuestions` — que são **respostas de triagem de saúde**

O identificador é um `_id` do Mongo, ou seja um ObjectId, que embute timestamp e counter — parcialmente enumerável.

Isso **já estava exposto** e independe da campanha YDUQS. Foi encontrado ao desenhar o comprovante público de pré-triagem, que justamente **não** pôde reusar este endpoint por causa disso.

## Como escolhi os campos

`grep` pelos acessos a `formResponse.*` no front: `_id`, `answers`, `failedQuestions`, `integration`, `mode`, `status`. Mantive também `user.name`, `user.id`, `donationIntent`, `startedAt` e `finishedAt` por conservadorismo. **`client` sai por completo** — nenhuma tela lê IP nem geolocalização, e é o campo mais sensível do documento.

## Notas de review

- **Allowlist, não denylist**, para falhar FECHADO quando alguém acrescentar campo sensível novo ao schema.
- `publicToken` está na lista porque é introduzido pelo PR do comprovante. Selecionar um path que ainda não existe no schema é no-op no Mongo, então este arquivo funciona **nas duas ordens de merge**.
- PR **separado da feature** de propósito: é correção pré-existente e não deve esperar o review da campanha.

## Não resolve

O endpoint continua **sem autenticação** — qualquer um com o `_id` lê as respostas de triagem de outra pessoa. Este PR reduz a superfície; fechar de vez exige decidir como o front prova posse do formulário, que hoje ele não faz. Vale issue própria.

## Verificação

Não percorri o questionário localmente: o cache do Yarn da máquina está corrompido e o `yarn install` falha na extração (ENOENT). A escolha de campos veio de grep sobre os call sites, e é conservadora — mas **vale percorrer o questionário no preview** (dois desfechos + um fluxo de integração de evento) antes de mergear, porque um campo faltando aqui quebra o fluxo em silêncio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted form response data returned to the frontend to only the necessary fields.
  * Improved data privacy by preventing unintended fields from being exposed through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->