### PR TITLE
fix(form-response): persistir competitionSlug no payload da integracao de evento

### DIFF
--- a/server/models/formResponse.ts
+++ b/server/models/formResponse.ts
@@ -74,6 +74,10 @@ IntegrationBaseSchema.discriminator(
       payload: {
         eventSlug: { type: String, required: true },
         eventDate: { type: Date, required: true },
+        // Slug da copa relacionada ao evento. SEM esta linha o Mongoose
+        // descarta o campo em strict mode, e o botao "Registrar participacao"
+        // nunca aparece para quem e reprovado na pre-triagem vindo de evento.
+        competitionSlug: { type: String, required: false },
       },
     },
     { _id: false }
@@ -87,6 +91,10 @@ IntegrationBaseSchema.discriminator(
       payload: {
         eventSlug: { type: String, required: true },
         eventDate: { type: Date, required: true },
+        // Slug da copa relacionada ao evento. SEM esta linha o Mongoose
+        // descarta o campo em strict mode, e o botao "Registrar participacao"
+        // nunca aparece para quem e reprovado na pre-triagem vindo de evento.
+        competitionSlug: { type: String, required: false },
       },
     },
     { _id: false }


### PR DESCRIPTION
## O bug

O discriminator do `event-flow-schedule` declarava apenas `eventSlug` e `eventDate`. Em strict mode o Mongoose **descarta** path não declarado, então `competitionSlug` era silenciosamente perdido na gravação.

Consequência: o botão **"Registrar participação"** nunca apareceria para quem é reprovado na pré-triagem vindo de um evento. O galho de evento da campanha ficava inteiro inerte.

## Como encontrei

Testando no ambiente de dev, antes do fix:

```
POST /api/v1/formResponse
  payload enviado:    {eventSlug, eventDate, competitionSlug}
  payload persistido: {eventSlug, eventDate}
```

## Por que nenhum teste pegou

A lógica dos botões estava correta e testada. O dado simplesmente nunca chegava nela — é falha de fiação, não de lógica, e teste de função pura não alcança.

Terceiro caso da mesma classe nesta feature: antes, `mode` não era aceito pelo `POST /competitions` e não era devolvido pelo `select` do getter da copa. Todos os três: código certo, dado não trafega, invisível na suíte.

## Verificação

`yarn build` compila. Diff é de 1 arquivo, 8 linhas. Vou reconfirmar o payload no dev depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L