### PR TITLE
fix(comprovante): gravar nome completo para o comprovante poder exibi-lo

### DIFF
--- a/server/services/formResponse.ts
+++ b/server/services/formResponse.ts
@@ -15,8 +15,15 @@ export async function createFormResponse(
 ) {
   const mode = user ? "logged-in" : "anonymous";
 
+  // Guarda nome COMPLETO: o comprovante publico de pre-triagem mostra
+  // "Primeiro I." e, com apenas o givenName, nunca teria o sobrenome para
+  // abreviar — sairia so o primeiro nome, fraco como prova de identidade.
   const userData = user
-    ? { id: user.id, name: user.givenName, email: user.email }
+    ? {
+        id: user.id,
+        name: [user.givenName, user.surName].filter(Boolean).join(" "),
+        email: user.email,
+      }
     : {};
 
   try {


### PR DESCRIPTION
## O bug

O comprovante público de pré-triagem mostra **"Primeiro I."** (ex.: `Thiago G.`), como no design aprovado. Mas o `createFormResponse` gravava:

```ts
name: user.givenName   // ❌ só o primeiro nome
```

mesmo tendo `surName` disponível no token de auth. Sem sobrenome, `formatDisplayName` não tinha o que abreviar — saía só o primeiro nome, fraco como prova de identidade num comprovante.

## Como apareceu

Testando no dev eu usei um `formResponse` **anônimo**, que cai no fallback `Doador(a)` — então o defeito ficou escondido. O Guima notou olhando o comprovante e perguntando onde estava o nome.

Lição: testar só o caminho anônimo não cobre o campo que só existe no caminho logado.

## Notas de review

- `[givenName, surName].filter(Boolean).join(" ")` — tolera sobrenome ausente.
- **Nenhum consumidor no front lê `formResponse.user.name`** (conferi por grep em `pages`, `layouts`, `components`, `stores`, `utils`), então a mudança não tem outro efeito.
- Não altera documentos já existentes: comprovantes antigos seguem mostrando o que foi gravado na época.

## Verificação

`yarn build` compila, `yarn test` 19 verdes. Vou conferir no dev com um `formResponse` **logado** depois do merge — é justamente o caso que faltou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form responses now display the respondent’s full name instead of only their first name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->