### PR TITLE
fix(config): URL da copa por ambiente em vez de default de dev

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,6 +32,11 @@ const getCurrentEnv = () => {
 };
 
 const siteUrl = getSiteUrl();
+
+const defaultCopaUrl =
+  process.env.VERCEL_ENV === "production"
+    ? "https://copa.hemocione.com.br"
+    : "https://copa.d.hemocione.com.br";
 const currentEnv = getCurrentEnv();
 export default defineNuxtConfig({
   // Habilitar ferramentas de desenvolvimento
@@ -55,7 +60,10 @@ export default defineNuxtConfig({
       eventosHemocione: process.env.EVENTOS_HEMOCIONE || "https://eventos.hemocione.com.br/",
       apoieHemocione: process.env.APOIE_HEMOCIONE || "https://apoie.hemocione.com.br/",
       ondeDoarHemocione: process.env.ONDE_DOAR_HEMOCIONE || "https://ondedoar.hemocione.com.br/",
-      copaHemocione: process.env.COPA_HEMOCIONE || "https://copa.d.hemocione.com.br",
+      // Derivado do ambiente: um default fixo de dev aqui levaria usuario de
+      // PRODUCAO para a copa de dev caso a env nao esteja setada — e o botao
+      // "Registrar participacao" e justamente o que manda a pessoa para la.
+      copaHemocione: process.env.COPA_HEMOCIONE || defaultCopaUrl,
       // Base sobre a qual o returnPath relativo das integracoes de copa e
       // resolvido. Nunca aceitamos URL completa por query string.
       yduqsSite: process.env.YDUQS_SITE || "https://yduqs.hemocione.com.br",


### PR DESCRIPTION
## O risco

O default era `https://copa.d.hemocione.com.br`. **Sem a env `COPA_HEMOCIONE` setada em produção, o botão "Registrar participação" mandaria usuário de produção para a copa de dev** — e esse botão é exatamente o caminho pelo qual a pessoa registra a participação dela.

Registro perdido, silenciosamente, no ambiente errado.

## O fix

`production` → `copa.hemocione.com.br`, `preview`/dev → o `.d`. Mesmo padrão do `siteUrl` que este arquivo já usa. A env continua tendo precedência, então dá para apontar um deploy específico para onde quiser.

## Por que existia

Escrevi o default apontando pra dev porque estava testando em dev. É a classe de erro que só aparece quando o código chega em produção — e produção ainda não recebeu nada dessa feature, então deu tempo.

## Verificação

`yarn build` compila.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copa now automatically uses the appropriate production or development environment URL.
  * Custom URL configuration remains supported through the existing override setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->