### PR TITLE
fix(participation): perguntar a data da doacao em vez de assumir hoje

### DIFF
--- a/pages/integration/[integrationSlug]/index.vue
+++ b/pages/integration/[integrationSlug]/index.vue
@@ -89,15 +89,21 @@ async function initializeQuestionnaire() {
   sessionStorage.setItem('questionnaireStarted', 'true');
 
   // 4. Cria FormResponse já com o payload da integração
-  if (intent) {
-    await userStore.createFormResponse(integrationSlug, payload, intent);
-    sessionStorage.setItem('selectedIntent', intent);
-    userStore.setDonationIntent(intent);
-  } else {
-    navigateTo('/');
+  await userStore.createFormResponse(integrationSlug, payload, intent);
+
+  // 5. Integração que NÃO sabe a data da doação (ex.: ida a um banco de sangue
+  //    por conta própria) deixa a pergunta para a própria pessoa: sem isso o
+  //    questionário assumiria um contexto errado e faria perguntas que só valem
+  //    para quem doa hoje.
+  if (!intent) {
+    router.replace('/intention');
+    return;
   }
 
-  // 5. Redireciona para a primeira pergunta
+  sessionStorage.setItem('selectedIntent', intent);
+  userStore.setDonationIntent(intent);
+
+  // 6. Redireciona para a primeira pergunta
   const firstQuestionSlug = userStore.formQuestions[0]?.slug;
   if (firstQuestionSlug) {
     nextQuestionUrl.value = `/questions/${firstQuestionSlug}`;

--- a/utils/integrations.ts
+++ b/utils/integrations.ts
@@ -38,7 +38,10 @@ export type ButtonConfig = {
   visible?: boolean;
 };
 
-type PayloadWithIntent = IntegrationPayload & { intent: "today" | "soon" };
+/** intent nulo significa "pergunte a pessoa" — ver pages/integration. */
+type PayloadWithIntent = IntegrationPayload & {
+  intent: "today" | "soon" | null;
+};
 
 export interface IntegrationDefinition {
   /** Constroi o payload que deve ser criado em << FormResponse.integration >>. */
@@ -307,9 +310,12 @@ export const integrations: Record<IntegrationSlug, IntegrationDefinition> = {
 
       const returnPath = asPlainString(route.query.returnPath) ?? "/apto";
 
-      // Fora de evento nao ha data marcada: a pessoa vai doar por conta
-      // propria, hoje.
-      return { intent: "today", competitionSlug, returnPath };
+      // intent NULO de proposito: fora de evento nao existe data marcada, e a
+      // pessoa vai ao banco de sangue quando preferir. Cravar "today" fazia o
+      // questionario perguntar "comeu hoje?", "dormiu bem?" e "bebeu?" — tres
+      // perguntas exclusivas do contexto de hoje — e reprovar quem so vai doar
+      // semana que vem. Quem responde e a propria pessoa, na tela /intention.
+      return { intent: null, competitionSlug, returnPath };
     },
 
     async getButtonConfig(formResponse) {


### PR DESCRIPTION
## O bug

A integração `competition-participation` cravava `intent: "today"`. Fora de evento **não existe data marcada** — a pessoa vai ao banco de sangue quando preferir.

E o `intent` decide **quais perguntas** o questionário faz. Três são exclusivas de quem doa hoje:

- "Você comeu hoje?"
- "Você dormiu bem?"
- "Você bebeu álcool?"

Com `today` cravado, quem pretende doar semana que vem era **reprovado por um motivo que não se aplica** — e reprovado é justamente quem cai no fluxo de registrar participação. O caminho funcionava, mas pelo motivo errado.

## O fix

O `intent` vem **nulo** e a pessoa responde na tela `/intention`, que já existia e faz `PUT` do intent no `formResponse` — a integração e o `competitionSlug` são preservados, então o resto do fluxo segue igual.

Escolhi deixar a pessoa responder em vez de trocar `today` por `soon` fixo: `soon` estaria certo na maioria dos casos, mas quem vai doar hoje mesmo deixaria de receber as perguntas que **deveria** receber. A pergunta existe porque a resposta muda o questionário.

## Verificação

`yarn build` compila, `yarn test` 19 verdes. Vou percorrer o fluxo em dev depois do merge, conferindo que a `/intention` aparece e que as perguntas mudam conforme a resposta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved questionnaire setup across integrations by creating responses consistently.
  * Integrations without a detected intent now direct you to the intention-selection step.
  * Integrations with a detected intent continue directly to the first questionnaire question.
  * Competition participation flows now correctly handle cases where no event date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->