### PR TITLE
feat(integrations): impor participacao no link de registro

### DIFF
--- a/utils/integrations.ts
+++ b/utils/integrations.ts
@@ -85,13 +85,18 @@ const buildEventsPayload = async (
 /**
  * URL de registro na copa.
  *
- * `kind` vem pre-selecionado mas permanece editavel no formulario da copa: o
- * campo e autodeclarado, entao mentir pelo query param equivale a mentir
- * clicando no radio — nao ha garantia perdida.
+ * `lockKind` faz a copa NAO perguntar "voce conseguiu doar?". Usado quando o
+ * link sai do resultado da pre-triagem: nesse momento a pessoa ainda nao doou,
+ * por definicao, e perguntar convidaria a resposta errada — que viraria bolsa
+ * de sangue no historico de quem nao doou.
  */
 export function buildCompetitionRegisterUrl(
   competitionSlug: string,
-  opts: { kind?: "donation" | "participation"; proofUrl?: string } = {},
+  opts: {
+    kind?: "donation" | "participation";
+    proofUrl?: string;
+    lockKind?: boolean;
+  } = {},
 ): string | null {
   const config = useRuntimeConfig();
   const base = (config.public.copaHemocione as string) ?? "";
@@ -104,6 +109,7 @@ export function buildCompetitionRegisterUrl(
     );
     if (opts.kind) url.searchParams.set("kind", opts.kind);
     if (opts.proofUrl) url.searchParams.set("proofUrl", opts.proofUrl);
+    if (opts.lockKind) url.searchParams.set("lockKind", "true");
     return url.toString();
   } catch {
     return null;
@@ -160,6 +166,7 @@ function buildEventButtonConfig(
   const registerUrl = competitionSlug
     ? buildCompetitionRegisterUrl(competitionSlug, {
         kind: "participation",
+        lockKind: true,
         proofUrl: buildComprovanteUrl(formResponse) ?? undefined,
       })
     : null;
@@ -353,6 +360,7 @@ export const integrations: Record<IntegrationSlug, IntegrationDefinition> = {
       const buttons: ButtonConfig[] = [];
       const registerUrl = buildCompetitionRegisterUrl(competitionSlug, {
         kind: "participation",
+        lockKind: true,
         proofUrl: buildComprovanteUrl(formResponse) ?? undefined,
       });
       if (registerUrl) {


### PR DESCRIPTION
## O que

Os dois links de **"Registrar participação"** — o do galho de evento e o do galho de banco de sangue — passam a incluir `lockKind=true`.

## Por que

Os dois saem do **resultado da pré-triagem**. Nesse momento a pessoa ainda não doou, por definição: ela está decidindo doar agora. O `kind=participation` já ia pré-selecionado, mas o radio continuava editável — e uma marcação errada ali vira bolsa de sangue no histórico de quem não doou.

Com o param, a copa não renderiza a pergunta. Par deste PR: `hemocione-competitions` que consome o `lockKind`.

## Ordem de deploy

Indiferente. Se este subir primeiro, a copa ignora o param desconhecido e o comportamento fica como hoje (radio pré-selecionado). Sem quebra em nenhuma ordem.

## Verificação

`yarn build` compila, `yarn test` 19 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration links for failed events and competition participation now preserve the selected participation type, reducing incorrect or ambiguous registration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->